### PR TITLE
Add nix flake for building

### DIFF
--- a/GPTune/__init__.py
+++ b/GPTune/__init__.py
@@ -15,3 +15,4 @@
 # other to do so.
 #
 
+from .gptune import *

--- a/README.md
+++ b/README.md
@@ -69,6 +69,74 @@ GPTune is part of the xSDK4ECP effort supported by the Exascale Computing Projec
 Our GPTune website at https://gptune.lbl.gov provides a shared database repository where the user can share their tuning performance data with other users.
 
 ## Installation
+
+### Installation using nix (for single-node systems)
+
+Nix may be used to install GPTune and all its dependencies on single-node systems, including personal computers and cloud servers (both with and without root access). Nix pulls in independent copies of GPTune's dependencies, and as a result it will neither affect nor be affected by the state of your system's packages.
+#### 1. Install Nix
+
+**If you have root access,** run this command to automatically install Nix, then immediately proceed to step 2:
+
+```sh <(curl -L https://nixos.org/nix/install) --daemon``` 
+
+For more details, see the [manual](https://nixos.org/manual/nix/stable/installation/installing-binary.html) for full details).
+
+**If you do *not* have root access,** you can install Nix as an unpriviliged user using one of [these] methods. For systems supporting user namespaces (follow the instructions [here](https://github.com/nix-community/nix-user-chroot#check-if-your-kernel-supports-user-namespaces-for-unprivileged-users) to check for user namespace support), including Debian, Ubuntu, and Arch, [nix-user-chroot](https://github.com/nix-community/nix-user-chroot) is recommended; the following steps may be used to install it. First, download the appropriate [static binary](https://github.com/nix-community/nix-user-chroot/releases) for your hardware platform:
+
+```
+#replace the link below with the appropriate build for your architecture
+wget -O nix-user-chroot https://github.com/nix-community/nix-user-chroot/releases/download/1.2.2/nix-user-chroot-bin-1.2.2-x86_64-unknown-linux-musl
+chmod +x nix-user-chroot
+#optionally, add nix-user-chroot to $PATH - you'll be running it a lot
+```
+
+Then, select an installation location. For this example, we will use `~/.nix`. Note that Nix will perform a significant amount of disk I/O to this location, so make sure that this directory is not located on a network drive (NFS, etc.) or builds may be slowed by up to an order of magnitude (for example, we recommend that UC Berkeley Millennium cluster users use a folder in `/scratch` or `/nscratch` instead). You may then install nix with:
+
+```
+mkdir -m 0755 ~/.nix
+./nix-user-chroot ~/.nix bash -c "curl -L https://nixos.org/nix/install | bash"
+```
+
+You may now enter the nix chroot environment with
+
+```./nix-user-chroot ~/.nix bash -l```
+
+This works much like a python virtualenv or conda shell - it will drop you into a environment where the Nix package manager and tools you have installed with Nix are available. As with a python virtualenv, you must be inside this environment in order to access tools (e.g. GPTune) that are installed with Nix (i.e. you must run it in each shell where you need these tools). All programs, files, etc. outside the environment should be accessible from within the environment as well.
+
+*Troubleshooting note: if you run into "out of space" errors during builds, set the `TMPDIR` environment variable when you run this command to a location on a disk with plenty of space, e.g. `TMPDIR=/scratch/dinh/tmp nix-user-chroot /scratch/dinh/.nix bash`*
+
+**If you do *not* have root access and your system does *not* support user namespaces**, you can [install Nix using proot](https://nixos.wiki/wiki/Nix_Installation_Guide#PRoot).
+
+#### 2: Enable nix flakes
+
+Nix flakes, which we use to build GPTune, are technically an experimental feature in nix (this is not a mark of instability - flakes have existed and been widely used for years, but remain marked as experimental since there's a slim possibility that their interface might change). As a result, they must be manually enabled, which can be done by adding this line:
+
+```
+experimental-features = nix-command flakes
+```
+
+to any one (or more) of the following locations (if the file(s) in question don't exist, feel free to create them):
+
+- `~/.config/nix/nix.conf` (recommended, affects your user account only)
+- `/etc/nix/nix.conf` (if you have root access, and want to enable flakes for everyone on your system)
+- `/nix/etc/nix/nix.conf` (for chroot-based installs only)
+
+#### 3: Build GPTune
+
+Clone the GPTune repo and cd into its directory:
+
+```
+git clone https://github.com/gptune/GPTune
+cd GPTune
+```
+
+then run
+
+```nix develop```
+
+to enter an environment where the `python` executable has all the dependencies needed.
+
+Alternatively, if you just want the C++ libraries for GPTune (e.g. to link with), run `nix build .#gptune-libs`, which will put the librarires in `result/gptune`.
 ### Installation using example scripts
 The following example build scripts are available for a collection of tested systems. 
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1662907018,
+        "narHash": "sha256-rMPfDmY7zJzv/tJj+LComcGEa1UuwI67kpbz5WC6abE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "17352e8995e1409636b0817a7f38d6314ccd73c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,325 @@
+{
+   description = "GPTune";
+
+  inputs = {
+    #Need unstable for openturns
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+      let
+        python = "python39";
+        version = builtins.substring 0 8 self.lastModifiedDate;
+
+        ######### Patched Packages ##########
+        pythonPackageOverrides = self: super: {
+          gpy = super.gpy.overridePythonAttrs ( oldAttrs: rec {
+            patchPhase = ''
+              cat ${./patches/GPy/coregionalize.py} > GPy/kern/src/coregionalize.py
+              cat ${./patches/GPy/stationary.py} > GPy/kern/src/stationary.py
+              cat ${./patches/GPy/choleskies.py} > GPy/util/choleskies.py
+            '';
+
+            # [TODO] send a pull request to nixpkgs to upstream the unbreak
+            # can confirm working on aarch64-darwin
+            meta.broken = false; 
+          });
+
+          #patch scikit to use numpy floats rather than regular floats
+          #gives consistent rounding behavior
+          scikit-optimize = super.scikit-optimize.overridePythonAttrs ( oldAttrs: rec {
+            patchPhase = ''
+              cat ${./patches/scikit-optimize/space.py} > skopt/space/space.py
+            '';
+            #patch breaks several pytests
+            disabledTests = [
+              #fails for floating point reasons
+              "utils"
+              #fails with attempt to iterate over float
+              "test_space"
+            ];
+            #comment out this line if you'd like to run other tests...
+            #takes a while but should pass
+            doCheck=false;
+          });
+        };
+
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            #python package patches
+            ( self: super: {
+              python39 = super.python39.override {
+                packageOverrides = pythonPackageOverrides;
+            };})
+          ] ++ nixpkgs.lib.optionals (system == "x86_64-darwin") [
+            #scalapack fails two tests out of 150 (xslu, xsllt) on x86 mac
+            #should still be fine for our purposes, so override to allow building
+            (self: super: {
+              scalapack = super.scalapack.overrideAttrs (oldAttrs: rec {
+                meta.broken = false;
+              });
+            })
+          ];
+        };
+
+        ########### SYSTEM PACKAGE DEPENDENCIES ##########
+        systemDeps = with pkgs; [
+          #defaults to openBLAS unless system blas changed
+          #see https://ryantm.github.io/nixpkgs/using/overlays#sec-overlays-alternatives-blas-lapack
+          #Might be interesting to see if using Accelerate is faster on darwin
+          blas
+          lapack
+          #fails a handful of tests on x86_64-darwin
+          scalapack
+          jq
+          tbb
+          openmpi
+        ];
+
+        ########## Extra Packages not in NixPkgs ###########
+        packagesExtra = rec {
+
+          cGP = pkgs.python39Packages.buildPythonPackage rec {
+            pname = "cGP";
+            version = "2022.01.27";
+            src = builtins.fetchGit{
+              url = "https://github.com/GPTune/cGP";
+              ref = "main";
+              rev = "1d5734b8fb35a7dadbf0b5b3f0077dc9c83527c9";
+            };
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              numpy
+              gpy
+              scikit-learn
+              scikit-optimize
+              scipy
+              dill
+            ];
+            doCheck = false; #no upstream checks
+            pythonImportsCheck = [ "cGP" ];
+          };
+
+          opentuner = pkgs.python39Packages.buildPythonPackage rec {
+            pname = "opentuner";
+            version = "0.8.8";
+            src = builtins.fetchGit{
+              url = "https://github.com/jansel/opentuner";
+              ref = "master";
+              rev = "05e2d6b9538c9e2d335a02c48c0f7e77d1c57077";
+            };
+            #remove argparse from requirements - built into python now
+            patchPhase = "sed '1d' requirements.txt > requirements.txt";
+            propagatedBuildInputs = [ pkgs.sqlite ]
+              ++ (with pkgs.python39Packages; [
+                numpy
+                sqlalchemy
+                future
+              ]);
+            buildInputs = with pkgs.python39Packages; [ setuptools ];
+            #checkInputs = [ pkgs.python39Packages.pytest ];
+            # [FIXME] reintroduce python checks
+            doCheck = false;
+          };
+
+          autotune = pkgs.python39Packages.buildPythonPackage rec {
+            pname = "autotune";
+            version = "2022.08.31";
+            src = builtins.fetchGit{
+              url = "https://github.com/ytopt-team/autotune";
+              ref = "master";
+              rev = "58f5d9a39106e3b2dbdea9ebcbe928a1b65bea6a";
+            };
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              numpy
+              scikit-optimize
+              setuptools
+            ];
+            checkPhase = "pythonImportsCheck";
+            doCheck = false;
+            pythonImportsCheck = [ "autotune" ];
+          };
+
+          lhsmdu = pkgs.python39Packages.buildPythonPackage rec {
+            pname = "lhsmdu";
+            version = "1.1";
+            src = pkgs.python39Packages.fetchPypi {
+              inherit pname version;
+              hash = "sha256-S8Hfa5zdJ7rgv/dc8Wk/RVujLk+ofKmpMvYGlmB/5xI=";
+            };
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              numpy
+              scipy
+            ];
+          };
+
+          hpbandster = pkgs.python39Packages.buildPythonPackage rec {
+            pname = "hpbandster";
+            version = "0.7.4";
+            src = pkgs.python39Packages.fetchPypi {
+              inherit pname version;
+              hash = "sha256-Sf/DJogVW1CeYvNhe1KuFalsm/8smWoj34PyeRBsWSE=";
+            };
+            propagatedBuildInputs = [ configspace ] ++ (with pkgs.python39Packages; [
+              Pyro4
+              serpent
+              numpy
+              statsmodels
+              scipy
+              netifaces
+            ]);
+            checkInputs = [ pkgs.python39Packages.unittestCheckHook ];
+            unittestFlags = [ "-s" "tests" "-v" ];
+          };
+
+          configspace = pkgs.python39Packages.buildPythonPackage rec {
+            pname = "ConfigSpace";
+            version = "0.6.0";
+            src = pkgs.python39Packages.fetchPypi {
+              inherit pname version;
+              hash = "sha256-m2yV2IOfyrIgNyZzIUsxKbRdzYsReYKessZXRsrLcqk=";
+            };
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              numpy
+              scipy
+              cython
+              pyparsing
+              typing-extensions
+            ];
+            checkInputs = [ pkgs.python39Packages.pytest ];
+          };
+
+          SALib = pkgs.python39Packages.buildPythonPackage rec {
+            pname = "SALib";
+            version = "1.4.5";
+            src = pkgs.python39Packages.fetchPypi {
+              inherit pname version;
+              hash = "sha256-zzlhduMN7VetZ9DRVPkXaJ+Pc+9cwdzTjUeW9DYQ2SU=";
+            };
+            propagatedBuildInputs = with pkgs.python39Packages; [
+              setuptools-scm
+              numpy
+              scipy
+              matplotlib
+              pandas
+              multiprocess
+              pathos
+            ];
+            checkInputs = with pkgs.python39Packages; [
+              pytestCheckHook
+              pytest
+              pytest-cov
+              #pytest-subprocess
+            ];
+            pytestFlagsArray = [ "tests/" ];
+            #these tests use subprocess, which doesn't work in nix build env
+            #can fake it with with pytest-subprocess, but it depends
+            #on pyopenssl which is currently broken on mac
+            #see GH issue: https://github.com/NixOS/nixpkgs/issues/175875
+            #possible fix: https://github.com/NixOS/nixpkgs/pull/187636
+            disabledTestPaths = [
+              "tests/test_cli.py"
+              "tests/test_cli_analyze.py"
+              "tests/test_cli_sample.py"
+            ];
+
+          };
+
+        };
+
+        ########## Python Definitions ###########
+
+        pydeps = ( with packagesExtra; [
+            autotune
+            cGP
+            opentuner
+            lhsmdu
+            hpbandster
+            SALib
+          ]) ++ ( with pkgs.python39Packages; [
+            scikit-optimize
+            joblib
+            scikit-learn
+            scipy
+            statsmodels
+            pyaml
+            matplotlib
+            gpy
+            openturns
+            ipyparallel
+            pygmo
+            filelock
+            requests
+            pymoo
+            mpi4py
+            cloudpickle
+          ]);
+
+        fullPythonWith = pypkg : ( pkgs.python39.buildEnv.override {
+          extraLibs = pydeps ++ [ pypkg ];
+        });
+
+      in
+      rec {
+
+        packages.gptune-libs = pkgs.stdenv.mkDerivation rec {
+          pname = "gptune-libs";
+          inherit version;
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [ cmake ];
+          buildInputs = systemDeps ++ [ pkgs.python39 ];
+
+          cmakeFlags = [
+            #"-DCMAKE_CXX_FLAGS=-fopenmp"
+            #"-DCMAKE_C_FLAGS=-fopenmp" 
+            #"-DCMAKE_Fortran_FLAGS=-fopenmp"
+          	"-DBUILD_SHARED_LIBS=ON"
+            "-DCMAKE_CXX_COMPILER=mpicxx"
+            "-DCMAKE_C_COMPILER=mpicc"
+            "-DCMAKE_Fortran_COMPILER=mpif90"
+	          "-DCMAKE_BUILD_TYPE=Release"
+            "-DGPTUNE_INSTALL_PATH=${placeholder "out"}"
+	          "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+            "-DTPL_BLAS_LIBRARIES=${pkgs.blas}/lib/libblas${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}"
+            "-DTPL_LAPACK_LIBRARIES=${pkgs.lapack}/lib/liblapack${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}" 
+            "-DTPL_SCALAPACK_LIBRARIES=${pkgs.scalapack}/lib/libscalapack${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}"
+          ] ++ pkgs.lib.optionals (pkgs.stdenv.isDarwin) [
+            "-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch"
+          ];
+
+          postInstall = ''
+            cat ${./setup.py} > $out/setup.py
+          '';
+        };
+
+        #packages.gptune-py-pkg = pkgs.python39Packages.toPythonModule packages.gptune-libs;
+
+        #GPTune as an importable python packages (do import GPTune, import GPTune.problem, etc.)
+        #note that this does NOT load the required libs, which are provided by gptune-libs
+        #certain files (specifically lcm.py) query GPTUNE_INSTALL_PATH to find them, and we MUST use them.
+        packages.gptune-py-pkg = pkgs.python39Packages.buildPythonPackage rec {
+          pname = "GPTune";
+          inherit version;
+          src = "${packages.gptune-libs}";
+          propagatedBuildInputs = pydeps;
+          doCheck = false;
+        };
+
+        #Main environment for use of GPTune, with the correct python packages preloaded
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = systemDeps ++ [ (fullPythonWith packages.gptune-py-pkg) packages.gptune-libs ];
+          shellHook = ''
+            export PYTHONWARNINGS=ignore
+            export GPTUNEROOT=$PWD
+            export GPTUNE_INSTALL_PATH=${packages.gptune-libs}/gptune/
+            export PYTHONPATH=$PYTHONPATH:${packages.gptune-libs}/gptune/
+          '';
+        };
+
+        defaultPackage = packages.gptune-libs;
+      });
+}

--- a/setup.py
+++ b/setup.py
@@ -55,4 +55,6 @@ setup(
   url='https://github.com/gptune/GPTune',
   install_requires=REQUIRED,
   extras_require=EXTRAS,
+  include_package_data=True,
+  package_data = {'GPTune': ['lib_*']}
 )


### PR DESCRIPTION
This pull request adds a nix flake for automated dependency fetching, building, and installation. Currently, this PR only includes the full GPTune; light mode will be coming soon.

In order to use it:

**1. Install Nix.** If you have root access, this command will perform an automatic installation:
```sh <(curl -L https://nixos.org/nix/install) --daemon``` (see the [manual](https://nixos.org/manual/nix/stable/installation/installing-binary.html) for full details); after running it, proceed to step 2. If you do *not* have root access, you can use [nix-user-chroot](https://github.com/nix-community/nix-user-chroot) to install a copy on your own account: download the [static binaries](https://github.com/nix-community/nix-user-chroot/releases), then run
```
mkdir -m 0755 ~/.nix
nix-user-chroot ~/.nix bash -c "curl -L https://nixos.org/nix/install | bash"
nix-user-chroot ~/.nix bash -l
```
You must then run `nix-user-chroot ~/.nix bash -l` in order to enter the nix chroot each time you want to access tools (including GPTune) installed with nix. Please note that this uses a tempfs on local memory to perform builds; if you run into "out of space" errors, manually set temporary location on disk, e.g. by using this command instead:
```
TMPDIR=/scratch/dinh/tmp nix-user-chroot /scratch/dinh/.nix bash
```

On Berkeley A machines, we strongly recommend replacing ~/.nix with a folder on /scratch for all commands (in the above example, we use /scratch/dinh/.nix), as /home is stored on extremely slow NFS volumes which will lead to ~10x slower build times.

**2: Enable nix flakes** Nix flakes are technically an experimental feature in nix (don't worry! Flakes have been out for years - the designation as experimental is more a statement that their interfaces might change than a mark of instability). Add the following line to ~/.config/nix/nix.conf or /etc/nix/nix.conf (on chroot-based nix installs, this will be /nix/etc/nix/nix.conf):
```
experimental-features = nix-command flakes
```
If the file does not exist, feel free to create it:

**3: Build GPTune** Clone the repo and cd into the GPTune directory (you can just download the .flake and .lock files and put them in the GPTune root directory if you have an existing copy). You can then run:

- `nix build .#gptune-libs` to compile C++ libraries (contents will be in `result/`)
- `nix develop` to get an environment where python has all the dependencies needed.

This PR still needs some fixes to python packaging, adding a shell hook modifying PYTHONPATH in nix develop, testing on linux, etc. so should be considered pre-alpha. Please let me know if you run into oddities or problems. Thanks!
